### PR TITLE
Enhancement for Cookie-based log-in

### DIFF
--- a/src/AbpCompanyName.AbpProjectName.WebMpa/Controllers/AccountController.cs
+++ b/src/AbpCompanyName.AbpProjectName.WebMpa/Controllers/AccountController.cs
@@ -100,7 +100,7 @@ namespace AbpCompanyName.AbpProjectName.WebMpa.Controllers
             var loginResult = await GetLoginResultAsync(
                 loginModel.UsernameOrEmailAddress,
                 loginModel.Password,
-                GetTenancyNameOrNull()
+                loginModel.TenancyName ?? GetTenancyNameOrNull()    // Gp - fix #xxx 
                 );
 
             await SignInAsync(loginResult.User, loginResult.Identity, loginModel.RememberMe);

--- a/src/AbpCompanyName.AbpProjectName.WebMpa/Models/Account/LoginViewModel.cs
+++ b/src/AbpCompanyName.AbpProjectName.WebMpa/Models/Account/LoginViewModel.cs
@@ -4,6 +4,8 @@ namespace AbpCompanyName.AbpProjectName.WebMpa.Models.Account
 {
     public class LoginViewModel
     {
+        public string TenancyName { get; set; } // Gp - fix #xxx
+
         [Required]
         public string UsernameOrEmailAddress { get; set; }
 

--- a/src/AbpCompanyName.AbpProjectName.WebMpa/Models/Users/EditUserModalViewModel.cs
+++ b/src/AbpCompanyName.AbpProjectName.WebMpa/Models/Users/EditUserModalViewModel.cs
@@ -13,7 +13,7 @@ namespace AbpCompanyName.AbpProjectName.WebMpa.Models.Users
 
         public bool UserIsInRole(RoleDto role)
         {
-            return User.Roles != null && User.Roles.Any(r => r == role.DisplayName);
+            return User.Roles != null && User.Roles.Any(r => r == role.Name);
         }
     }
 }

--- a/src/AbpCompanyName.AbpProjectName.WebSpaAngular/Controllers/AccountController.cs
+++ b/src/AbpCompanyName.AbpProjectName.WebSpaAngular/Controllers/AccountController.cs
@@ -105,7 +105,7 @@ namespace AbpCompanyName.AbpProjectName.WebSpaAngular.Controllers
             var loginResult = await GetLoginResultAsync(
                 loginModel.UsernameOrEmailAddress,
                 loginModel.Password,
-                GetTenancyNameOrNull()
+                loginModel.TenancyName ?? GetTenancyNameOrNull()    // Gp - fix #xxx 
             );
 
             await SignInAsync(loginResult.User, loginResult.Identity, loginModel.RememberMe);


### PR DESCRIPTION
As Cookie-based login does not accept the tenancy name on the POST, tenant-login requires a preceding POST for selecting the tenancy name. The problem does not affect Token-based login.

This limitation can be seen in the [aspnetboilerplate-samples](https://github.com/aspnetboilerplate/aspnetboilerplate-samples/blob/master/ConsoleRemoteWebApiCall/CallApiFromConsole/MyTestClient.cs) where token-based login works perfectly, while cookie-based long works only on current Host/Tenant.

Patch proposed here, is compatible with current implementation and offers the possibility to optionally pass the tenancy in the POST for the login